### PR TITLE
Add unmaintained notice to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+**This repo is no longer mantained, `fly` should instead be installed by downloading it from your Concourse web interface (ATC).**
+
+---
+
 # Concourse Homebrew Tap
 
 ## Usage


### PR DESCRIPTION
Based on the conversation at https://github.com/concourse/homebrew-tap/issues/1, people should no longer be using this tap.